### PR TITLE
Add leading zeroes to page numbers when importing documents

### DIFF
--- a/python/import-data.py
+++ b/python/import-data.py
@@ -22,7 +22,7 @@ class NormalizeRegex:
     FILE_NAME = re.compile(r'[^a-z\/.0-9]+', flags=re.IGNORECASE)
     DIRECTORY_NAME = re.compile(r'[^a-z\/0-9]+', flags=re.IGNORECASE)
     REPLACEMENT = '-'
-    PAGE_NUMBER = re.compile(r'(?P<page>\d+)(?:(r|v)\.)', re.MULTILINE)
+    PAGE_NUMBER = re.compile(r'(?P<page>\d+)(?:(r|v)?\.)', re.MULTILINE)
 
 
 def build_output_file_name(file_name, remove_root_dir, output_root_dir):


### PR DESCRIPTION
Existing documents are sorted in lexicographical order which doesn't preserve page sequence.

The existing documents need to be sorted by prepending page numbers with leading zeroes. The same should apply to the documents that are generated by splitting pdf files. 