### PR TITLE
Check if page name contains number

### DIFF
--- a/python/import-data.py
+++ b/python/import-data.py
@@ -161,6 +161,10 @@ def enforce_page_order(directory):
     padding = len(str(num_pages))
     for page in pages:
         page_number = NormalizeRegex.PAGE_NUMBER.search(str(page))
+        if (not page_number) or (not page_number.group('page')):
+            message = "Could not determine page number for [{}.]"
+            logging.warning(message.format(str(page)))
+            continue
         page_number = int(page_number.group('page'))
         name = re.sub(
             pattern,


### PR DESCRIPTION
If one of the files for which to enforce page order doesn't contain a number in its name issue a warning and continue.

Closes #7.