### PR TITLE
Display a warning for files that cannot be imported

### DIFF
--- a/python/import-data.py
+++ b/python/import-data.py
@@ -312,13 +312,19 @@ def parse_arguments():
         help=
         "Specifies the token that joins the PDF file name and the page number. Default is 'pagina'.",
         default='pagina')
+    parser.add_argument(
+        '--log-level',
+        help="The level of details to print when running.",
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        default='INFO')
     return parser.parse_args()
 
 
 if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',
-                        level=logging.INFO)
     args = parse_arguments()
+    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',
+                        level=getattr(logging, args.log_level))
+
     import_data(args.input_file, args.include_files, args.remove_root_dir,
                 args.output_dir, args.pdf_split_page_tag)
     logging.info("That's all folks!")

--- a/python/import-data.py
+++ b/python/import-data.py
@@ -233,7 +233,7 @@ def process_archive_content_file(zip_archive, file_name, remove_root_dir,
                                          output_dir)
     is_importable, requires_splitting = can_import(output_path)
     if not is_importable:
-        logging.info("[{}] cannot be imported. Skipping.".format(file_name))
+        logging.warning("[{}] cannot be imported. Skipping.".format(file_name))
         return
 
     parent_dir = Path(output_path.parent)


### PR DESCRIPTION
At the moment, only manual adjustments to the file are available to make the import succeed.

Closes #9.