### PR TITLE
Renamed `export-lexicon` to `export-common-lexicon`

### DIFF
--- a/.github/workflows/export-common-lexicon.yml
+++ b/.github/workflows/export-common-lexicon.yml
@@ -1,4 +1,4 @@
-name: Export Lexicon
+name: Export Common Lexicon
 
 on:
   push:

--- a/.github/workflows/export-common-lexicon.yml
+++ b/.github/workflows/export-common-lexicon.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Update pipelines
         run: ssh -p ${{secrets.SSH_PORT}} ${{secrets.USERNAME}}@${{secrets.HOST}} 'cd rocc-pipelines && git pull'
       - name: Prepare export script
-        run: ssh -p ${{secrets.SSH_PORT}} ${{secrets.USERNAME}}@${{secrets.HOST}} 'cd rocc-pipelines && chmod u+x ./export-lexicon.sh'
+        run: ssh -p ${{secrets.SSH_PORT}} ${{secrets.USERNAME}}@${{secrets.HOST}} 'cd rocc-pipelines && chmod u+x ./export-common-lexicon.sh'
       - name: Run export
-        run: ssh -p ${{secrets.SSH_PORT}} ${{secrets.USERNAME}}@${{secrets.HOST}} 'cd rocc-pipelines && ./export-lexicon.sh ${{secrets.DB_SERVER}} ${{secrets.DB_NAME}} ${{secrets.DB_USERNAME}} ${{secrets.DB_PASSWORD}}'
+        run: ssh -p ${{secrets.SSH_PORT}} ${{secrets.USERNAME}}@${{secrets.HOST}} 'cd rocc-pipelines && ./export-common-lexicon.sh ${{secrets.DB_SERVER}} ${{secrets.DB_NAME}} ${{secrets.DB_USERNAME}} ${{secrets.DB_PASSWORD}}'

--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The contents of the output directory are as follows:
 - several directories containing the images of the annotated pages such that the path of the images corresponds to the path specified in the column `page_image_file` from the CSV file.
 
 
-### Export Lexii ###
+### Export Common Lexii ###
 
-- **Script name**: [export-lexicon.py](./export-lexicon.py)
+- **Script name**: [export-common-lexicon.py](./export-common-lexicon.py)
 - **Description**: This script reads line annotations from database and integral transcribed files for each collection (where available), groups data into periods of 50 years and builds lexicon for each period.
 
 #### Usage  ####
@@ -171,20 +171,17 @@ The contents of the output directory are as follows:
 To get the list of the script parameters with their description call the script with either `-h` or `--help` *after activating the virtual environment*.
 
 ```sh
-python export-lexicon.py --help
+python export-common-lexicon.py --help
 ```
 
 The output of the command above should look like the following:
 ```sh
-usage: export-lexicon.py [-h] --db-server DB_SERVER --db-name DB_NAME --user USER --password
-                         PASSWORD [--port PORT] [--output-dir OUTPUT_DIR] [--write-header]
-                         [--size-stats-file SIZE_STATS_FILE]
-                         [--terms-per-periods-file TERMS_PER_PERIODS_FILE]
-                         [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+usage: export-common-lexicon.py [-h] --db-server DB_SERVER --db-name DB_NAME --user USER --password PASSWORD [--port PORT] [--output-dir OUTPUT_DIR] [--write-header]
+                                [--size-stats-file SIZE_STATS_FILE] [--terms-per-periods-file TERMS_PER_PERIODS_FILE] [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
 
-Export lexicon
+Export common lexicon
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --db-server DB_SERVER
                         Name or IP address of the database server.
@@ -205,7 +202,7 @@ optional arguments:
 
 To run the script, *activate the virtual environment* and then issue the following command
 ```sh
-python export-lexicon.py \
+python export-common-lexicon.py \
        --db-server <database-server> \
        --db-name <database-name> \
        --user <username> \

--- a/export-common-lexicon.py
+++ b/export-common-lexicon.py
@@ -1,4 +1,4 @@
-"""Exports lexicons from line annotations and transcribed files."""
+"""Exports common lexicons from line annotations and transcribed files."""
 import argparse
 import logging
 import spacy
@@ -395,7 +395,7 @@ def run(args):
 
 def parse_arguments():
     """Parse command-lne arguments."""
-    parser = argparse.ArgumentParser(description='Export lexicon')
+    parser = argparse.ArgumentParser(description='Export common lexicon')
     parser.add_argument('--db-server',
                         help="Name or IP address of the database server.",
                         required=True)

--- a/export-common-lexicon.sh
+++ b/export-common-lexicon.sh
@@ -1,0 +1,7 @@
+source .venv/bin/activate;
+python -m spacy download ro_core_news_lg
+python export-common-lexicon.py --db-server $1 --db-name $2 --user $3 --password $4 --output-dir ./common-lexii
+deactivate;
+zip -r common-lexii.zip common-lexii;
+mv -f common-lexii.zip /var/export/;
+rm -rf ./common-lexii

--- a/export-lexicon.sh
+++ b/export-lexicon.sh
@@ -1,7 +1,0 @@
-source .venv/bin/activate;
-python -m spacy download ro_core_news_lg
-python export-lexicon.py --db-server $1 --db-name $2 --user $3 --password $4 --output-dir ./lexii
-deactivate;
-zip -r lexii.zip lexii;
-mv -f lexii.zip /var/export/;
-rm -rf ./lexii


### PR DESCRIPTION
In order to avoid confusion and conflicts with upcoming changes, `export-lexicon` was renamed to `export-common-lexicon` throughout scripts and actions; closes #30.