### PR TITLE
Added possibility to export a fraction of letter annotations

### DIFF
--- a/.github/workflows/export-yolov5-annotations.yml
+++ b/.github/workflows/export-yolov5-annotations.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       imageSize:
         description: 'Width and height of the exported images.'
-        default: '2048'
+        required: true
       topLabels:
         description: 'Fraction of top labels to export (between 0 and 1).'
         required: true

--- a/.github/workflows/export-yolov5-annotations.yml
+++ b/.github/workflows/export-yolov5-annotations.yml
@@ -7,7 +7,7 @@ on:
         description: 'Width and height of the exported images.'
         default: '2048'
       topLabels:
-        description: 'Percentage of top labels to export.'
+        description: 'Fraction of top labels to export (between 0 and 1).'
         required: true
 
 jobs:

--- a/.github/workflows/export-yolov5-annotations.yml
+++ b/.github/workflows/export-yolov5-annotations.yml
@@ -6,6 +6,9 @@ on:
       imageSize:
         description: 'Width and height of the exported images.'
         default: '2048'
+      topLabels:
+        description: 'Percentage of top labels to export.'
+        required: true
 
 jobs:
   export:
@@ -33,6 +36,6 @@ jobs:
       - name: Prepare export script
         run: ssh -p ${{secrets.SSH_PORT}} ${{secrets.USERNAME}}@${{secrets.HOST}} 'cd rocc-pipelines && chmod u+x ./export-yolov5-annotations.sh'
       - name: Run export
-        run: ssh -p ${{secrets.SSH_PORT}} ${{secrets.USERNAME}}@${{secrets.HOST}} 'cd rocc-pipelines && ./export-yolov5-annotations.sh ${{secrets.DB_SERVER}} ${{secrets.DB_NAME}} ${{secrets.DB_USERNAME}} ${{secrets.DB_PASSWORD}} ${{github.event.inputs.imageSize}}'
+        run: ssh -p ${{secrets.SSH_PORT}} ${{secrets.USERNAME}}@${{secrets.HOST}} 'cd rocc-pipelines && ./export-yolov5-annotations.sh ${{secrets.DB_SERVER}} ${{secrets.DB_NAME}} ${{secrets.DB_USERNAME}} ${{secrets.DB_PASSWORD}} ${{github.event.inputs.imageSize}} ${{github.event.inputs.topLabels}}'
       - name: Reset git changes
         run: ssh -p ${{secrets.SSH_PORT}} ${{secrets.USERNAME}}@${{secrets.HOST}} 'cd rocc-pipelines && git checkout -- .'

--- a/export-yolov5-annotations.py
+++ b/export-yolov5-annotations.py
@@ -355,5 +355,3 @@ if __name__ == '__main__':
                         level=getattr(logging, args.log_level))
     main(args)
     logging.info("That's all folks!")
-    main(args)
-    logging.info("That's all folks!")

--- a/export-yolov5-annotations.py
+++ b/export-yolov5-annotations.py
@@ -331,6 +331,10 @@ def parse_arguments():
         help="The port of the database server. Default value is 5432.",
         default="5432")
 
+    parser.add_argument('--top-labels',
+                        help="Percentage of top labels to export.",
+                        type=float,
+                        default=0.1)
     parser.add_argument(
         '--output-dir',
         help="The output directory. Default value is './yolo-export'.",

--- a/export-yolov5-annotations.sh
+++ b/export-yolov5-annotations.sh
@@ -3,10 +3,11 @@ DB_NAME=$2
 USER=$3
 PASSWORD=$4
 IMG_SIZE=${5:-2048}
+TOP_LABELS=${6:-1}
 
 rm -rf yolo-export
 source .venv/bin/activate;
-python export-yolov5-annotations.py --db-server $DB_SERVER --db-name $DB_NAME --user $USER --password $PASSWORD --image-size $IMG_SIZE $IMG_SIZE;
+python export-yolov5-annotations.py --db-server $DB_SERVER --db-name $DB_NAME --user $USER --password $PASSWORD --image-size $IMG_SIZE $IMG_SIZE --top-labels $TOP_LABELS;
 deactivate;
 zip -r yolov5-annotations.zip yolo-export/letters;
 mv -f yolov5-annotations.zip /var/export/


### PR DESCRIPTION
The export of Yolo v5 annotations was changed to allow the user to select a fraction of top labels to export. Closes #52.