### PR TITLE
Fixed issue with missing images in the validation directory

### DIFF
--- a/export-yolov5-annotations.py
+++ b/export-yolov5-annotations.py
@@ -210,9 +210,6 @@ def export_char_annotations(args):
     logging.info("Creating export directories for letter annotations.")
     staging_dir, train_dir, val_dir, yaml_file = create_export_directories(
         args.output_dir, export_type='characters')
-    train, val = train_test_split(letters_df.to_numpy(),
-                                  test_size=TEST_SIZE,
-                                  random_state=RANDOM_SEED)
 
     logging.info("Exporting data to staging directory {}.".format(
         str(staging_dir)))
@@ -225,12 +222,13 @@ def export_char_annotations(args):
     blur_out_negative_samples(staging_dir,
                               num_workers=args.blur_workers,
                               verbosity=blur_verbosity)
-    if not DEBUG_MODE:
-        shutil.rmtree(staging_dir)
+
+    logging.info("Exporting training data.")
 
     logging.info("Exporting validation data.")
-    export_collection(val, val_dir, image_size_dict, args.image_size,
-                      labels_map, args.binary_read)
+
+    if not DEBUG_MODE:
+        shutil.rmtree(staging_dir)
     labels = sorted(labels_map, key=labels_map.get)
 
     logging.info(

--- a/export-yolov5-annotations.py
+++ b/export-yolov5-annotations.py
@@ -216,7 +216,6 @@ def export_char_annotations(args):
     logging.info("Blurring unmarked letters from all images.")
     blur_verbosity = 11 if DEBUG_MODE else 0
     blur_out_negative_samples(staging_dir,
-                              train_dir,
                               num_workers=args.blur_workers,
                               verbosity=blur_verbosity)
     if not DEBUG_MODE:

--- a/export-yolov5-annotations.py
+++ b/export-yolov5-annotations.py
@@ -5,6 +5,7 @@ import logging
 from utils.exportutils import load_annotations, create_directories
 from utils.exportutils import export_image, export_yolov5_annotation
 from utils.exportutils import save_dataset_description, blur_out_negative_samples
+from utils.exportutils import get_cv2_image_size
 from pathlib import Path
 import shutil
 
@@ -168,7 +169,7 @@ def export_collection(annotations, destination_directory, image_size,
                 image_width, image_height, binary_read)
             if image_exported:
                 img = cv.imread(file_name)
-                original_size_dict[image_name] = img.shape
+                original_size_dict[image_name] = get_cv2_image_size(img)
             else:
                 logging.error("Could not export image {}.".format(file_name))
                 continue

--- a/utils/exportutils.py
+++ b/utils/exportutils.py
@@ -90,7 +90,7 @@ def scale_point(point, original_size, export_size):
     scaled_point: tuple of (int, int)
         The point scaled from original image size to exported image size.
     """
-    original_height, original_width, _ = original_size
+    original_width, original_height = original_size
     export_width, export_height = export_size
     x_scale = export_width / original_width
     y_scale = export_height / original_height

--- a/utils/exportutils.py
+++ b/utils/exportutils.py
@@ -301,7 +301,7 @@ def get_path_for_move(file_name, target_dir):
     return target_dir / file_path.name
 
 
-def apply_mask_and_export(image_file, labels_file, export_dir):
+def apply_mask(image_file, labels_file):
     """Apply mask to the provided image file and export it with labels file.
 
     Parameters
@@ -310,8 +310,6 @@ def apply_mask_and_export(image_file, labels_file, export_dir):
         The image to blur and export.
     labels_file: str, required
         The labels file.
-    export_dir: pathlib.Path, required
-        The path of the export directory.
     """
     letters = []
     img = cv.imread(image_file)
@@ -325,10 +323,7 @@ def apply_mask_and_export(image_file, labels_file, export_dir):
     mask = create_mask(min_top_left, max_bottom_right, img_size)
     img = eliminate_all_letters_from_image(img, mask)
     img = put_letters_back(img, letters)
-    train_image_path = get_path_for_move(image_file, export_dir)
-    cv.imwrite(str(train_image_path), img)
-    labels = Path(labels_file)
-    labels = labels.rename(get_path_for_move(labels_file, export_dir))
+    cv.imwrite(image_file, img)
 
 
 def blur_out_negative_samples(staging_dir,
@@ -348,8 +343,8 @@ def blur_out_negative_samples(staging_dir,
         use all but one CPUs.
     """
     Parallel(n_jobs=num_workers, verbose=verbosity)(
-        delayed(apply_mask_and_export)(img_file, labels_file, train_dir)
-        for img_file, labels_file in iterate_yolo_directory(staging_dir))
+        delayed(apply_mask)(img_file, labels_file)
+        for img_file, labels_file in iterate_yolo_directory(data_dir))
 
 
 def export_image(src_path, dest_path, width, height, binary_read):

--- a/utils/exportutils.py
+++ b/utils/exportutils.py
@@ -326,18 +326,13 @@ def apply_mask(image_file, labels_file):
     cv.imwrite(image_file, img)
 
 
-def blur_out_negative_samples(staging_dir,
-                              train_dir,
-                              num_workers=-2,
-                              verbosity=0):
+def blur_out_negative_samples(data_dir, num_workers=-2, verbosity=0):
     """Apply a blur mask on the unannotated letters in the images.
 
     Parameters
     ----------
-    staging_dir: pathlib.Path, required
+    data_dir: pathlib.Path, required
         Directory containing original, resized images.
-    train_dir: pathlib.Path, required
-        Directory where we copy the images after being cleaned of negative samples.
     num_workers: int, optional
         The maximum number of concurrently processed images. Default is -2 which means
         use all but one CPUs.

--- a/utils/exportutils.py
+++ b/utils/exportutils.py
@@ -414,3 +414,20 @@ names: {names}
                                 val=val,
                                 nc=len(labels),
                                 names=names))
+
+
+def move_images_and_labels(images_and_labels, source_dir, destination_dir):
+    """Move the specified collection of images and labels from source to destination directory.
+
+    Parameters
+    ----------
+    images_and_labels: iterable of tuples of (str, str), required
+        The collection of tuples (image_name, labels_name) to move from source to destination directory.
+    source_dir: pathlib.Path, required
+        The source directory.
+    destination_dir: pathlib.Path, required
+        The destination directory.
+    """
+    for image, labels in images_and_labels:
+        image.rename(destination_dir / image.name)
+        labels.rename(destination_dir / labels.name)

--- a/utils/yolov5utils.py
+++ b/utils/yolov5utils.py
@@ -61,7 +61,7 @@ def iterate_yolo_directory(directory_path, image_extension='.png'):
 
     Returns
     -------
-    iterator of (image, labels_file): iterator of tuple of (str, str)
+    iterator of (image, labels_file): iterator of tuple of (pathlib.Path, pathlib.Path)
         The pairs of image file and associated labels file.
     """
     for image_file in directory_path.glob("*{}".format(image_extension)):
@@ -70,4 +70,4 @@ def iterate_yolo_directory(directory_path, image_extension='.png'):
             logging.warning(
                 "Could not find labels file for image {}.".format(image_file))
             continue
-        yield str(image_file), str(labels_file)
+        yield image_file, labels_file


### PR DESCRIPTION
After being loaded from database, annotations are exported into the staging directory (images are resized, and labels are exported to labels files). Afterwards, the images from the staging directory are split into `train` and `val` collections using `train_test_split` with `test_size=0.2`.

To simplify the implementation and because it wasn't used, the method for exporting letter annotations was removed. If needed the method will be added in the future.

This pull request closes #90.