### PR TITLE
Added possibility to export images in original size

### DIFF
--- a/export-yolov5-annotations.py
+++ b/export-yolov5-annotations.py
@@ -163,13 +163,12 @@ def export_annotations(annotations, destination_directory, image_size,
         and labels_map maps labels to their indices.
     """
     original_size_dict, labels_map = {}, {}
-    image_width, image_height = image_size
     for file_name, letter, *coords in annotations:
         image_name, labels_name = get_export_file_names(file_name)
         if image_name not in original_size_dict:
             image_exported = export_image(
-                file_name, str(destination_directory / image_name),
-                image_width, image_height, binary_read)
+                file_name, str(destination_directory / image_name), image_size,
+                binary_read)
             if image_exported:
                 img = cv.imread(file_name)
                 original_size_dict[image_name] = get_cv2_image_size(img)

--- a/export-yolov5-annotations.py
+++ b/export-yolov5-annotations.py
@@ -287,12 +287,12 @@ def add_common_arguments(parser):
         help="The output directory. Default value is './yolo-export'.",
         default='./yolo-export')
 
-    parser.add_argument(
-        '--image-size',
-        help="The size of the exported images. Default is [1024, 768].",
-        type=int,
-        nargs=2,
-        default=[1024, 786])
+    parser.add_argument('--image-size',
+                        help="""The size of the exported images.
+                        If omitted, the images will be exported in original resolution.""",
+                        type=int,
+                        nargs=2,
+                        default=None)
 
     parser.add_argument('--binary-read',
                         help="Sample the images as black and white.",

--- a/utils/exportutils.py
+++ b/utils/exportutils.py
@@ -342,7 +342,7 @@ def blur_out_negative_samples(data_dir, num_workers=-2, verbosity=0):
         for img_file, labels_file in iterate_yolo_directory(data_dir))
 
 
-def export_image(src_path, dest_path, width, height, binary_read):
+def export_image(src_path, dest_path, image_size, binary_read):
     """Export and resize the image.
 
     Parameters
@@ -351,10 +351,8 @@ def export_image(src_path, dest_path, width, height, binary_read):
         The source path of the image.
     dest_path: str, required
         The destination path of the image.
-    width: int, required
-        Width of the exported image.
-    height: int, required
-        Height of the exported image.
+    image_size: tuple of (int, int), required
+        The size of the exporte image in (width, height) format.
 
     Returns
     -------
@@ -371,8 +369,8 @@ def export_image(src_path, dest_path, width, height, binary_read):
         source_img = cv.adaptiveThreshold(source_img, 255,
                                           cv.ADAPTIVE_THRESH_MEAN_C,
                                           cv.THRESH_BINARY, 11, 2)
-
-    resized_img = cv.resize(source_img, (width, height))
+    if image_size is not None:
+        resized_img = cv.resize(source_img, image_size)
     cv.imwrite(dest_path, resized_img)
     return True
 


### PR DESCRIPTION
The script for exporting Yolo v5 annotations was refactored to accept a default value of `None` for `--image-size` argument. When this argument is omitted, i.e. the default value of `None` is passed, the script will export images in their original size.

This pull request closes #97.